### PR TITLE
Add support for new SIS login

### DIFF
--- a/download.html
+++ b/download.html
@@ -5,13 +5,10 @@
 	<title>RIT Food Data</title>
 	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
 	<script src="http://code.highcharts.com/highcharts.js"></script>
+	<meta http-equiv="refresh" content="2;URL=https://sis.rit.edu/portalServices/exportfoodtranscsv.do?sdate=08012014&edate=05302015">
 	<link rel="stylesheet" href="style.css">
 </head>
 <body>
-	<!--
-	<iframe id="eservices" hidden src="https://sis.rit.edu/portalServices/exportfoodtranscsv.do?sdate=08012013&edate=05302014"></iframe>
-	-->
-	<iframe id="myIframe" src="https://sis.rit.edu/portalServices/exportfoodtranscsv.do?sdate=08012014&edate=05302015" style="position:absolute;left:-1000px;top:0px;height:0px;width:0px;"></iframe>
 	<div id="page-wrapper">
 		<h3>
 		Close this tab when the download is complete.

--- a/download.html
+++ b/download.html
@@ -3,8 +3,6 @@
 <head>
 	<meta charset="utf-8">
 	<title>RIT Food Data</title>
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
-	<script src="http://code.highcharts.com/highcharts.js"></script>
 	<meta http-equiv="refresh" content="2;URL=https://sis.rit.edu/portalServices/exportfoodtranscsv.do?sdate=08012014&edate=05302015">
 	<link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
RIT's new SIS login no longer uses HTTP authentication, and doesn't allow for frames.

Solution: redirect to the SIS dump. If the user is already logged in, it'll be as if nothing changed. If they aren't logged in, they'll be presented with the "Close this tab when the download is complete." for two seconds, then be redirected to the SIS login page and continue the process.

Though I feel this could be simplified even more using a javascript request to SIS, and if it returns a 302 status code, redirect the user to SIS to login. The only issue there would be instructing them to get out of SIS and try the request again..
